### PR TITLE
過去のPDF版遅延証明書を一覧に追加

### DIFF
--- a/src/pages/videos.js
+++ b/src/pages/videos.js
@@ -17,19 +17,25 @@ const LEGACY_DELAY_CERTIFICATES = [
   {
     id: "legacy-2022-11-08",
     scheduledAt: "2022-11-08T18:00:00+09:00",
-    title: "過去のPDF版遅延証明書",
+    title: "【ケチ】いつでもできるJRの限界節約方法100選",
+    videoUrl: "https://youtu.be/XCMAEwvU3J8",
+    delayMinutes: 13455,
     href: "/certificate/certificate_of_delay_2022-11-08.pdf",
   },
   {
     id: "legacy-2022-08-20",
     scheduledAt: "2022-08-20T18:00:00+09:00",
-    title: "過去のPDF版遅延証明書",
+    title: "仕事を押し付け合うスマートスピーカーを作った",
+    videoUrl: "https://www.youtube.com/shorts/cyPCHMy15SI",
+    delayMinutes: 225,
     href: "/certificate/certificate_of_delay_2022-08-20.pdf",
   },
   {
     id: "legacy-2022-08-13",
     scheduledAt: "2022-08-13T18:00:00+09:00",
-    title: "過去のPDF版遅延証明書",
+    title: "【特定厨】花火の動画から居場所を特定するのちょろすぎて草",
+    videoUrl: "https://youtu.be/DXSQ_hkZyW8",
+    delayMinutes: 210,
     href: "/certificate/certificate_of_delay_2022-08-13.pdf",
   },
 ];
@@ -211,10 +217,9 @@ class VideosPage extends Component {
           <table className="table is-bordered is-striped is-narrow is-hoverable is-fullwidth">
             <thead>
               <tr>
-                <th>予定日時</th>
-                <th>対象動画</th>
+                <th>日時</th>
+                <th>タイトル</th>
                 <th>遅れ</th>
-                <th>証明書</th>
               </tr>
             </thead>
             <tbody>
@@ -231,9 +236,8 @@ class VideosPage extends Component {
   renderCertificateRow(certificate) {
     return (
       <tr key={certificate.id}>
-        <td>{formatDateTime(certificate.scheduledAt)}</td>
+        <td>{formatDate(certificate.scheduledAt)}</td>
         <td>{certificate.title}</td>
-        <td>{certificate.delayLabel}</td>
         <td>
           {certificate.href ? (
             <a
@@ -242,11 +246,11 @@ class VideosPage extends Component {
               target="_blank"
               rel="noopener noreferrer"
             >
-              PDF
+              {certificate.delayLabel}
             </a>
           ) : (
             <Link className="button is-primary" to={certificate.to}>
-              表示
+              {certificate.delayLabel}
             </Link>
           )}
         </td>
@@ -296,7 +300,7 @@ const delaySectionStyles = `
 }
 `;
 
-function formatDateTime(value) {
+function formatDate(value) {
   if (!value) {
     return "";
   }
@@ -305,8 +309,6 @@ function formatDateTime(value) {
     year: "numeric",
     month: "long",
     day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
     timeZone: "Asia/Tokyo",
   }).format(new Date(value));
 }
@@ -350,7 +352,12 @@ function buildCertificateRows(certificates, mockMode) {
   }));
   const legacyRows = LEGACY_DELAY_CERTIFICATES.map(certificate => ({
     ...certificate,
-    delayLabel: "PDF版",
+    title: (
+      <a target="_blank" rel="noopener noreferrer" href={certificate.videoUrl}>
+        {certificate.title}
+      </a>
+    ),
+    delayLabel: formatMinutes(certificate.delayMinutes),
   }));
 
   return [...electronicRows, ...legacyRows].sort(

--- a/src/pages/videos.js
+++ b/src/pages/videos.js
@@ -13,6 +13,26 @@ import {
 import "./animista.css";
 
 const API_PATH = "/.netlify/functions/delay-certificates";
+const LEGACY_DELAY_CERTIFICATES = [
+  {
+    id: "legacy-2022-11-08",
+    scheduledAt: "2022-11-08T18:00:00+09:00",
+    title: "過去のPDF版遅延証明書",
+    href: "/certificate/certificate_of_delay_2022-11-08.pdf",
+  },
+  {
+    id: "legacy-2022-08-20",
+    scheduledAt: "2022-08-20T18:00:00+09:00",
+    title: "過去のPDF版遅延証明書",
+    href: "/certificate/certificate_of_delay_2022-08-20.pdf",
+  },
+  {
+    id: "legacy-2022-08-13",
+    scheduledAt: "2022-08-13T18:00:00+09:00",
+    title: "過去のPDF版遅延証明書",
+    href: "/certificate/certificate_of_delay_2022-08-13.pdf",
+  },
+];
 
 class VideosPage extends Component {
   constructor(props) {
@@ -168,70 +188,69 @@ class VideosPage extends Component {
       certificateError,
       mockMode,
     } = this.state;
+    const certificateRows = buildCertificateRows(certificates, mockMode);
 
-    if (loadingCertificates) {
+    if (!certificateRows.length && loadingCertificates) {
       return <p>遅延証明書を読み込んでいます。</p>;
     }
 
-    if (certificateError) {
-      return (
-        <div className="notification is-warning">
-          <p>{certificateError}</p>
-          <p>Netlify Functions の初回実行後に一覧が表示されます。</p>
-        </div>
-      );
-    }
-
-    if (!certificates.length) {
-      return (
-        <div className="notification is-info">
-          現在、発行済みの遅延証明書はありません。
-        </div>
-      );
-    }
-
     return (
-      <table className="table is-bordered is-striped is-narrow is-hoverable is-fullwidth">
-        <thead>
-          <tr>
-            <th>予定日時</th>
-            <th>対象動画</th>
-            <th>遅れ</th>
-            <th>証明書</th>
-          </tr>
-        </thead>
-        <tbody>
-          {certificates.map(certificate => (
-            <tr key={certificate.id}>
-              <td>{formatDateTime(certificate.scheduledAt)}</td>
-              <td>
-                {certificate.videoUrl ? (
-                  <a
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href={certificate.videoUrl}
-                  >
-                    {certificate.videoTitle}
-                  </a>
-                ) : (
-                  statusLabel(certificate.status)
-                )}
-              </td>
-              <td>{formatMinutes(getEffectiveDelayMinutes(certificate))}</td>
-              <td>
-                <Link
-                  className="button is-primary"
-                  to={`/delay-certificate?id=${encodeURIComponent(
-                    certificate.id
-                  )}${getMockQuerySuffix(mockMode)}`}
-                >
-                  表示
-                </Link>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <>
+        {loadingCertificates ? <p>遅延証明書を読み込んでいます。</p> : null}
+        {certificateError ? (
+          <div className="notification is-warning">
+            <p>{certificateError}</p>
+            <p>電子版の取得に失敗した場合も、過去のPDF版は表示されます。</p>
+          </div>
+        ) : null}
+        {!certificateRows.length ? (
+          <div className="notification is-info">
+            現在、発行済みの遅延証明書はありません。
+          </div>
+        ) : (
+          <table className="table is-bordered is-striped is-narrow is-hoverable is-fullwidth">
+            <thead>
+              <tr>
+                <th>予定日時</th>
+                <th>対象動画</th>
+                <th>遅れ</th>
+                <th>証明書</th>
+              </tr>
+            </thead>
+            <tbody>
+              {certificateRows.map(certificate =>
+                this.renderCertificateRow(certificate)
+              )}
+            </tbody>
+          </table>
+        )}
+      </>
+    );
+  }
+
+  renderCertificateRow(certificate) {
+    return (
+      <tr key={certificate.id}>
+        <td>{formatDateTime(certificate.scheduledAt)}</td>
+        <td>{certificate.title}</td>
+        <td>{certificate.delayLabel}</td>
+        <td>
+          {certificate.href ? (
+            <a
+              className="button is-primary"
+              href={certificate.href}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              PDF
+            </a>
+          ) : (
+            <Link className="button is-primary" to={certificate.to}>
+              表示
+            </Link>
+          )}
+        </td>
+      </tr>
     );
   }
 }
@@ -311,6 +330,32 @@ function formatMinutes(minutes) {
 
 function formatDelayStatus(minutes) {
   return `${formatMinutes(minutes)}遅れ`;
+}
+
+function buildCertificateRows(certificates, mockMode) {
+  const electronicRows = certificates.map(certificate => ({
+    id: certificate.id,
+    scheduledAt: certificate.scheduledAt,
+    title: certificate.videoUrl ? (
+      <a target="_blank" rel="noopener noreferrer" href={certificate.videoUrl}>
+        {certificate.videoTitle}
+      </a>
+    ) : (
+      statusLabel(certificate.status)
+    ),
+    delayLabel: formatMinutes(getEffectiveDelayMinutes(certificate)),
+    to: `/delay-certificate?id=${encodeURIComponent(
+      certificate.id
+    )}${getMockQuerySuffix(mockMode)}`,
+  }));
+  const legacyRows = LEGACY_DELAY_CERTIFICATES.map(certificate => ({
+    ...certificate,
+    delayLabel: "PDF版",
+  }));
+
+  return [...electronicRows, ...legacyRows].sort(
+    (a, b) => new Date(b.scheduledAt) - new Date(a.scheduledAt)
+  );
 }
 
 function getEffectiveDelayMinutes(certificate) {

--- a/src/pages/videos.js
+++ b/src/pages/videos.js
@@ -217,9 +217,10 @@ class VideosPage extends Component {
           <table className="table is-bordered is-striped is-narrow is-hoverable is-fullwidth">
             <thead>
               <tr>
-                <th>日時</th>
-                <th>タイトル</th>
+                <th>予定日時</th>
+                <th>対象動画</th>
                 <th>遅れ</th>
+                <th>証明書</th>
               </tr>
             </thead>
             <tbody>
@@ -236,21 +237,22 @@ class VideosPage extends Component {
   renderCertificateRow(certificate) {
     return (
       <tr key={certificate.id}>
-        <td>{formatDate(certificate.scheduledAt)}</td>
+        <td>{formatDateTime(certificate.scheduledAt)}</td>
         <td>{certificate.title}</td>
+        <td>{certificate.delayLabel}</td>
         <td>
-          {certificate.href ? (
+          {certificate.href && certificate.documentLabel ? (
             <a
               className="button is-primary"
               href={certificate.href}
               target="_blank"
               rel="noopener noreferrer"
             >
-              {certificate.delayLabel}
+              {certificate.documentLabel}
             </a>
           ) : (
             <Link className="button is-primary" to={certificate.to}>
-              {certificate.delayLabel}
+              {certificate.documentLabel}
             </Link>
           )}
         </td>
@@ -300,7 +302,7 @@ const delaySectionStyles = `
 }
 `;
 
-function formatDate(value) {
+function formatDateTime(value) {
   if (!value) {
     return "";
   }
@@ -309,6 +311,8 @@ function formatDate(value) {
     year: "numeric",
     month: "long",
     day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
     timeZone: "Asia/Tokyo",
   }).format(new Date(value));
 }
@@ -346,6 +350,7 @@ function buildCertificateRows(certificates, mockMode) {
       statusLabel(certificate.status)
     ),
     delayLabel: formatMinutes(getEffectiveDelayMinutes(certificate)),
+    documentLabel: "表示",
     to: `/delay-certificate?id=${encodeURIComponent(
       certificate.id
     )}${getMockQuerySuffix(mockMode)}`,
@@ -358,6 +363,7 @@ function buildCertificateRows(certificates, mockMode) {
       </a>
     ),
     delayLabel: formatMinutes(certificate.delayMinutes),
+    documentLabel: "PDF",
   }));
 
   return [...electronicRows, ...legacyRows].sort(


### PR DESCRIPTION
## 概要
- `/videos` の遅延証明書一覧に、既存の2022年PDF版遅延証明書を表示するようにしました。
- 電子版の取得に失敗した場合でも、過去PDF版は一覧に表示されます。

## 確認
- `PATH=/tmp/codex-node16/bin:$PATH LOCAL_DESIGN_PREVIEW=1 npm run build`
